### PR TITLE
Remove setting of the parentColumn

### DIFF
--- a/src/NestableCollection.php
+++ b/src/NestableCollection.php
@@ -21,7 +21,6 @@ class NestableCollection extends Collection
     public function __construct($items = [])
     {
         parent::__construct($items);
-        $this->parentColumn = 'parent_id';
         $this->total = count($items);
     }
 


### PR DESCRIPTION
If we remove the setting of the parent column then it inherits the name of the relationship function for example:

public function children(){
  return $this->hasMany('App\Models\User');
}

would inherit the name children.
