### PR TITLE
Added setIndent()

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,23 @@ By default it will look for a `title` column. You can send a custom column name 
 Model::orderBy('parent_id')->get()->nest()->listsFlattened('name');
 ```
 
+Four spaces are used to indent by default, to use your own use the `setIndent()` method, followed by the `listsFlattened()` method:
+
+```php
+Model::orderBy('parent_id')->get()->nest()->setIndent('> ')->listsFlattened();
+```
+
+Results:
+
+```php
+[
+    '22' => 'Item 1 Title',
+    '10' => '> Child 1 Title',
+    '17' => '> Child 2 Title',
+    '14' => 'Item 2 Title',
+]
+```
+
 ## Nesting a subtree
 
 This package remove items that have missing ancestor, this doesn’t allow you to nest a branch of a tree.

--- a/src/NestableCollection.php
+++ b/src/NestableCollection.php
@@ -108,7 +108,7 @@ class NestableCollection extends Collection
      * @param string $indentChars
      * @return $this
      */
-    public function setIndentChars(string $indentChars) {
+    public function setIndent(string $indentChars) {
         $this->indentChars = $indentChars;
         return $this;
     }

--- a/src/NestableCollection.php
+++ b/src/NestableCollection.php
@@ -18,6 +18,7 @@ class NestableCollection extends Collection
     private $total;
     private $parentColumn;
     private $removeItemsWithMissingAncestor = true;
+    private $indentChars = '&nbsp;&nbsp;&nbsp;&nbsp;';
 
     public function __construct($items = [])
     {
@@ -87,9 +88,10 @@ class NestableCollection extends Collection
      *
      * @return array
      */
-    public function listsFlattened($column = 'title', BaseCollection $collection = null, $level = 0, array &$flattened = [], $indentChars = '&nbsp;&nbsp;&nbsp;&nbsp;')
+    public function listsFlattened($column = 'title', BaseCollection $collection = null, $level = 0, array &$flattened = [], $indentChars = null)
     {
         $collection = $collection ?: $this;
+        $indentChars = $indentChars ?: $this->indentChars;
         foreach ($collection as $item) {
             $flattened[$item->id] = str_repeat($indentChars, $level).$item->$column;
             if ($item->items) {
@@ -98,6 +100,17 @@ class NestableCollection extends Collection
         }
 
         return $flattened;
+    }
+
+    /**
+     * Change the default indent characters when flattening lists
+     *
+     * @param string $indentChars
+     * @return $this
+     */
+    public function setIndentChars(string $indentChars) {
+        $this->indentChars = $indentChars;
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Added the ability to override the default indent characters without having to pass all params to `listsFlattened`. This maintains all default behavior of `listsFlattened`.

Example Usage: 

```
Model::orderBy('parent_id')->get()->nest()->setIndent('- ')->listsFlattened('name');
```