### PR TITLE
Remove scalar type hint

### DIFF
--- a/src/NestableCollection.php
+++ b/src/NestableCollection.php
@@ -132,7 +132,7 @@ class NestableCollection extends Collection
      *
      * @return $this
      */
-    public function setIndent(string $indentChars)
+    public function setIndent($indentChars)
     {
         $this->indentChars = $indentChars;
 


### PR DESCRIPTION
As scalar type hint requires php >= 7.x this package won't be compatible with PHP < 7.x