### PR TITLE
Fix for Lumen 5.7 compatibility.

### DIFF
--- a/src/NestableCollection.php
+++ b/src/NestableCollection.php
@@ -55,7 +55,7 @@ class NestableCollection extends Collection
         // Add empty collection to each items.
         $collection = $this->each(function ($item) {
             if (!$item->{$this->childrenName}) {
-                $item->{$this->childrenName} = App::make('Illuminate\Support\Collection');
+                $item->{$this->childrenName} = app()->make('Illuminate\Support\Collection');
             }
         });
 


### PR DESCRIPTION
The `App` class isn't available in Lumen 5.7. The `app()` helper function should do the same thing on both platforms.