### PR TITLE
Check one parent id shoud be null.

### DIFF
--- a/src/NestableCollection.php
+++ b/src/NestableCollection.php
@@ -49,11 +49,11 @@ class NestableCollection extends Collection
             return $this;
         }
 
-        //check at least one parent_id should be 0
-        $checkAtLeastOneParentIdShouldBeZero = $this->pluck($this->parentColumn)->contains(0);
+        //check at least one parent_id should be null
+        $checkAtLeastOneParentIdShouldBeNull = $this->pluck($this->parentColumn)->contains(null);
 
-        if (!$checkAtLeastOneParentIdShouldBeZero) {
-            throw new Exception('At least one '.$this->parentColumn.' should be 0.');
+        if (!$checkAtLeastOneParentIdShouldBeNull) {
+            throw new Exception('At least one '.$this->parentColumn.' should be null.');
         }
 
         // Set id as keys.

--- a/src/NestableCollection.php
+++ b/src/NestableCollection.php
@@ -10,6 +10,7 @@
 namespace TypiCMS;
 
 use App;
+use Exception;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
@@ -46,6 +47,13 @@ class NestableCollection extends Collection
         $parentColumn = $this->parentColumn;
         if (!$parentColumn) {
             return $this;
+        }
+        
+        //check at least one parent_id should be 0
+        $checkAtLeastOneParentIdShouldBeZero = $this->pluck($this->parentColumn)->contains(0);
+
+        if(!$checkAtLeastOneParentIdShouldBeZero) {
+            throw new Exception('At least one '.$this->parentColumn.' should be 0.');
         }
 
         // Set id as keys.

--- a/src/NestableCollection.php
+++ b/src/NestableCollection.php
@@ -48,7 +48,7 @@ class NestableCollection extends Collection
         if (!$parentColumn) {
             return $this;
         }
-        
+
         //check at least one parent_id should be 0
         $checkAtLeastOneParentIdShouldBeZero = $this->pluck($this->parentColumn)->contains(0);
 

--- a/src/NestableCollection.php
+++ b/src/NestableCollection.php
@@ -52,7 +52,7 @@ class NestableCollection extends Collection
         //check at least one parent_id should be 0
         $checkAtLeastOneParentIdShouldBeZero = $this->pluck($this->parentColumn)->contains(0);
 
-        if(!$checkAtLeastOneParentIdShouldBeZero) {
+        if (!$checkAtLeastOneParentIdShouldBeZero) {
             throw new Exception('At least one '.$this->parentColumn.' should be 0.');
         }
 


### PR DESCRIPTION
If you have more than one category and there is no parent id with value zero then you get proc_open(): fork failed - Cannot allocate memory error. To fix this error i have check at least one parent id should be 0.