### PR TITLE
Fixed incorrect typehinting

### DIFF
--- a/src/NestableCollection.php
+++ b/src/NestableCollection.php
@@ -186,7 +186,7 @@ class NestableCollection extends Collection
         return $this;
     }
 
-    protected function setParentsRecursive(self &$items, &$parent = null): void
+    protected function setParentsRecursive(BaseCollection &$items, &$parent = null): void
     {
         foreach ($items as $item) {
             if ($parent) {


### PR DESCRIPTION
The typehinting for setParentsRecursive was incorrect. The nested collections are Illuminate\Support\Collection instances and not NestableCollection instances.