### PR TITLE
Add method to set parent column name

### DIFF
--- a/src/NestableCollection.php
+++ b/src/NestableCollection.php
@@ -34,6 +34,13 @@ class NestableCollection extends Collection
         $this->total = count($items);
     }
 
+    public function parentColumn($name)
+    {
+        $this->parentColumn = $name;
+
+        return $this;
+    }
+
     public function childrenName(string $name): self
     {
         $this->childrenName = $name;


### PR DESCRIPTION
Parent column name can be set if using a custom name for id column.